### PR TITLE
array initialization syntax

### DIFF
--- a/src/usr.bin/openssl/crl.c
+++ b/src/usr.bin/openssl/crl.c
@@ -198,7 +198,7 @@ static struct option crl_options[] = {
 		.type = OPTION_FLAG,
 		.opt.flag = &crl_config.verify,
 	},
-	{},
+	{0},
 };
 
 static void

--- a/src/usr.bin/openssl/ecparam.c
+++ b/src/usr.bin/openssl/ecparam.c
@@ -245,7 +245,7 @@ struct option ecparam_options[] = {
 		.type = OPTION_FLAG,
 		.opt.flag = &ecparam_config.text,
 	},
-	{},
+	{0},
 };
 
 static void

--- a/src/usr.bin/openssl/prime.c
+++ b/src/usr.bin/openssl/prime.c
@@ -96,7 +96,7 @@ struct option prime_options[] = {
 		.type = OPTION_FLAG,
 		.opt.flag = &prime_config.safe,
 	},
-	{},
+	{0},
 };
 
 static void

--- a/src/usr.bin/openssl/rand.c
+++ b/src/usr.bin/openssl/rand.c
@@ -99,7 +99,7 @@ struct option rand_options[] = {
 		.type = OPTION_ARG,
 		.opt.arg = &rand_config.outfile,
 	},
-	{},
+	{0},
 };
 
 static void

--- a/src/usr.bin/openssl/version.c
+++ b/src/usr.bin/openssl/version.c
@@ -200,7 +200,7 @@ static struct option version_options[] = {
 		.type = OPTION_FLAG,
 		.opt.flag = &version_config.version,
 	},
-	{},
+	{0},
 };
 
 static void


### PR DESCRIPTION
As closed issue like this,
libressl-portable/portable#25
http://freshbsd.org/commit/openbsd/ab4c457c6a0238cc273f5496fa17101a930e9efc
 use C array initialization syntax for strict C compilers.

Thanks.
