### PR TITLE
Fix small memory leak in tls_verify.c

### DIFF
--- a/src/lib/libtls/tls_verify.c
+++ b/src/lib/libtls/tls_verify.c
@@ -155,7 +155,7 @@ tls_check_subject_altname(X509 *cert, const char *host)
 		}
 	}
 
-	sk_GENERAL_NAME_free(altname_stack);
+	sk_GENERAL_NAME_pop_free(altname_stack, GENERAL_NAME_free);
 	return rv;
 }
 


### PR DESCRIPTION
Replaced sk_GENERAL_NAME_free with sk_GENERAL_NAME_pop_free in tls_check_subject_altname to fix memory leak.
sk_GENERAL_NAME_free only frees the stack but not the content, sk_GENERAL_NAME_pop_free also frees the content.
