### PR TITLE
modify for strict C compiler.

### DIFF
--- a/src/lib/libssl/src/crypto/gost/gost2814789.c
+++ b/src/lib/libssl/src/crypto/gost/gost2814789.c
@@ -416,7 +416,7 @@ GOST2814789IMIT_Init(GOST2814789IMIT_CTX *c, int nid)
 }
 
 static void
-GOST2814789IMIT_block_data_order(GOST2814789IMIT_CTX *ctx, const void *p,
+GOST2814789IMIT_block_data_order(GOST2814789IMIT_CTX *ctx, const unsigned char *p,
     size_t num)
 {
 	int i;

--- a/src/lib/libssl/src/crypto/gost/gostr341194.c
+++ b/src/lib/libssl/src/crypto/gost/gostr341194.c
@@ -207,7 +207,7 @@ GOSTR341194_Init(GOSTR341194_CTX *c, int nid)
 }
 
 static void
-GOSTR341194_block_data_order(GOSTR341194_CTX *ctx, const void *p, size_t num)
+GOSTR341194_block_data_order(GOSTR341194_CTX *ctx, const unsigned char *p, size_t num)
 {
 	int i;
 

--- a/src/lib/libssl/src/crypto/gost/streebog.c
+++ b/src/lib/libssl/src/crypto/gost/streebog.c
@@ -1268,7 +1268,7 @@ streebog_single_block(STREEBOG_CTX *ctx, const unsigned char *in, size_t num)
 
 
 static void
-streebog_block_data_order(STREEBOG_CTX *ctx, const void *in, size_t num)
+streebog_block_data_order(STREEBOG_CTX *ctx, const unsigned char *in, size_t num)
 {
 	int i;
 
@@ -1281,10 +1281,10 @@ STREEBOG512_Final(unsigned char *md, STREEBOG_CTX *c)
 {
 	int n;
 	unsigned char *p = (unsigned char *)c->data;
-	STREEBOG_LONG64 Z[STREEBOG_LBLOCK] = {};
+	STREEBOG_LONG64 Z[STREEBOG_LBLOCK] = {0};
 
 	if (c->num == STREEBOG_CBLOCK) {
-		streebog_block_data_order(c, c->data, 1);
+		streebog_block_data_order(c, (unsigned char *)c->data, 1);
 		c->num -= STREEBOG_CBLOCK;
 	}
 


### PR DESCRIPTION
- incrementing void pointer is undefined, gcc treats it as char pointer, though.
- array initialization by '{}' causes compilation error with strict C compiler.
