### PR TITLE
sizeof Style Issue

### DIFF
--- a/src/lib/libc/crypt/arc4random.c
+++ b/src/lib/libc/crypt/arc4random.c
@@ -86,7 +86,7 @@ _rs_stir(void)
 {
 	u_char rnd[KEYSZ + IVSZ];
 
-	if (getentropy(rnd, sizeof rnd) == -1)
+	if (getentropy(rnd, sizeof(rnd)) == -1)
 		_getentropy_fail();
 
 	if (!rs)


### PR DESCRIPTION
Since sizeof in the rest of the file always has parentheses, this one should not be an exception.
