### PR TITLE
Add brainpool curves to the tls default curves.

### DIFF
--- a/src/lib/libssl/src/ssl/t1_lib.c
+++ b/src/lib/libssl/src/ssl/t1_lib.c
@@ -249,12 +249,15 @@ static const unsigned char ecformats_default[] = {
 static const unsigned char eccurves_default[] = {
 	0,14,			/* sect571r1 (14) */
 	0,13,			/* sect571k1 (13) */
-	0,25,			/* secp521r1 (25) */	
+	0,25,			/* secp521r1 (25) */
+	0,28,			/* brainpool512r1 (28) */
 	0,11,			/* sect409k1 (11) */
 	0,12,			/* sect409r1 (12) */
+	0,27,			/* brainpoolP384r1 (27) */
 	0,24,			/* secp384r1 (24) */
 	0,9,			/* sect283k1 (9) */
 	0,10,			/* sect283r1 (10) */
+	0,26,			/* brainpoolP256r1 (26) */
 	0,22,			/* secp256k1 (22) */
 	0,23,			/* secp256r1 (23) */
 	0,8,			/* sect239k1 (8) */


### PR DESCRIPTION
this fixes using the brainpool curves for TLS connections. ported from
openssl commit 469bcb0c24ba6360ca8f6f5660314fa11a8294f3.

see:

https://github.com/openssl/openssl/commit/469bcb0c24ba6360ca8f6f5660314fa11a8294f3
