### PR TITLE
x86_64cpuid.pl: zap _CET_ENDBR opcode from the init section

### DIFF
--- a/src/lib/libcrypto/x86_64cpuid.pl
+++ b/src/lib/libcrypto/x86_64cpuid.pl
@@ -18,7 +18,6 @@ print<<___;
 .extern		OPENSSL_cpuid_setup
 .hidden		OPENSSL_cpuid_setup
 .section	.init
-	_CET_ENDBR
 	call	OPENSSL_cpuid_setup
 
 .extern	OPENSSL_ia32cap_P


### PR DESCRIPTION
Before this patch, an `endbr*` opcode was present in the `.init` section.

This caused a crash on startup in MinGW builds for example (possibly also in MSVC builds), as seen in 3.8.3 and 3.9.0 releases (also in 3.8.0/3.8.1).

`x86_64-xlate.pl` is not prepared to handle CPU opcodes in this segment, reinforced by its header comment:
https://github.com/libressl/openbsd/blob/bf5599144609e046ba98f40a58158132af34faeb/src/lib/libcrypto/perlasm/x86_64-xlate.pl#L57

Affected platforms expect a list of function pointers in the `.init` section, and were crashing when making the first call, which was in fact the `_CET_ENDBR` opcode, not a valid function address.

Ref: https://github.com/libressl/portable/issues/1015