### PR TITLE
Fix error handling in PKCS7 repacking functions

### DIFF
--- a/src/lib/libcrypto/pkcs12/p12_npas.c
+++ b/src/lib/libcrypto/pkcs12/p12_npas.c
@@ -276,11 +276,11 @@ PKCS12_newpass(PKCS12 *pkcs12, const char *oldpass, const char *newpass)
 
 		switch (OBJ_obj2nid(pkcs7->type)) {
 		case NID_pkcs7_data:
-			if (pkcs7_repack_data(pkcs7, safes, oldpass, newpass))
+			if (!pkcs7_repack_data(pkcs7, safes, oldpass, newpass))
 				goto err;
 			break;
 		case NID_pkcs7_encrypted:
-			if (pkcs7_repack_encdata(pkcs7, safes, oldpass, newpass))
+			if (!pkcs7_repack_encdata(pkcs7, safes, oldpass, newpass))
 				goto err;
 			break;
 		}


### PR DESCRIPTION
Both pkcs7_repack_data() and pkcs7_repack_encdata() return error as 0. 

Thanks to Frank Denis.